### PR TITLE
add cache for grade service

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ pyparsing==2.2.0
 six==1.10.0
 wcwidth==0.1.7
 yarl==0.10.1
+redis

--- a/service/__init__.py
+++ b/service/__init__.py
@@ -24,3 +24,4 @@ def create_app():
 
 app = create_app()
 loop = asyncio.get_event_loop()
+

--- a/service/api.py
+++ b/service/api.py
@@ -1,7 +1,9 @@
+import json
 from aiohttp import web
 from aiohttp.web import Response
 from .spider import get_grade
 from .decorator import require_info_login
+from .redis import redis_client
 
 api = web.Application()
 
@@ -15,14 +17,22 @@ async def grade_all_api(request, s, sid, ip):
             keys.append(_.split('=')[0])
             vals.append(_.split('=')[1])
         args = dict(zip(keys, vals))
+        #xqm:第一学期３，第二学期12
+        # xnm: 学年 2016,2017...　
         xnm = args.get('xnm'); xqm = args.get('xqm')
-        gradeList = await get_grade(s, sid, ip, xnm, xqm)
-        if gradeList:
-            return web.json_response(gradeList)
+        key=sid+"_"+xnm+"_"+xqm
+        val=redis_client.get(key)
+        if val is not None:
+            return web.json_response(json.loads(val))
         else:
-            return Response(body=b'', content_type='application/json', status=403)
-# =================================
+            gradeList = await get_grade(s, sid, ip, xnm, xqm)
+            if gradeList:
+                redis_client.set(key,json.dumps(gradeList),ex=126144000)#过期时间为4年
+                return web.json_response(gradeList)
+            else:
+                return Response(body=b'', content_type='application/json', status=403)
+    # =================================
 
 # ====== url --------- maps  ======
 api.router.add_route('GET', '/grade/', grade_all_api, name='grade_all_api')
-# =================================
+# ==============================

--- a/service/decorator.py
+++ b/service/decorator.py
@@ -23,7 +23,8 @@ def require_info_login(f):
             # 网络请求info_login_service拿到cookie进行
             headers = {
                 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.96 Safari/537.36',
-                'Authorization': auth, 'Tag': 'v1'
+                'Authorization': auth,
+                'Tag': 'v1'
             }
             conn = aiohttp.TCPConnector(verify_ssl=False)
             async with aiohttp.ClientSession(headers=headers, connector=conn) as session:

--- a/service/redis.py
+++ b/service/redis.py
@@ -1,0 +1,5 @@
+import os
+import redis
+redis_host=os.environ.get("REDIS_HOST") or "localhost"
+redis_port=os.environ.get("REDIS_PORT") or 6379
+redis_client=redis.Redis(host=redis_host, port=redis_port,decode_responses=True)

--- a/service/spider.py
+++ b/service/spider.py
@@ -35,18 +35,18 @@ async def get_grade_perpage(s, sid, ip, xnm, xqm, payload):
                 _gradeList = json_data.get('items')
                 for _ in _gradeList:
                     grade = {
-                        'course'  : _.get('kcmc'),
+                        'course'  : _.get('kcmc'),#课程名
                         'credit'  : _.get('xf'),
                         'grade'   : _.get('cj'),
                         'category': _.get('kclbmc'),
                         'type'    : _.get('kcgsmc'),
-                        'jxb_id'  : _.get('jxb_id'),
+                        'jxb_id'  : _.get('jxb_id'),#514C496E56E25636E0531D50A8C0F546,不知道这一项是干什么的？？？
                         'kcxzmc'  : _.get('kcxzmc')
                     }
                     if xqm == "":
                         _xqm = _.get('xqm')
                     else: _xqm = xqm
-                    await get_grade_detail(session, sid, xnm, _xqm, grade)
+                    await get_grade_detail(session, sid, xnm, _xqm, grade) 
                     gradeList.append(grade)
                 return gradeList
             except aiohttp.client_exceptions.ClientResponseError:


### PR DESCRIPTION
grade_service做的工作是在每一个用户发来请求的时候，就去学校网站上爬取该用户的成绩信息，然后返回给用户。我测试了一下，这个过程平均在5秒钟左右。这让人崩溃!

于是我们采用了redis内存缓存的做法：用户第一次查询成绩的时候，爬取成绩信息，并且存入redis,以后查成绩就直接从redis取信息。

缓存策略为:以sid+"_"+xnm+"_"+xqm的字符串作为key,然后以成绩列表的序列化后的结果作为值，然后存入redis,过期时间设置为4年。

改进之后，用户的非首次查询只用了不到0.2秒。